### PR TITLE
Add base text component

### DIFF
--- a/components/BaseText.tsx
+++ b/components/BaseText.tsx
@@ -1,0 +1,36 @@
+import styles from '@/styles/BaseText.module.sass'
+
+type Props = {
+  tagName?: keyof JSX.IntrinsicElements
+  face?: 'normal' | 'ja' | 'en'
+  weight?: 'r' | 'm' | 'b'
+  className?: string
+  sizeSp: number
+  sizePc: number
+  children: React.ReactNode
+}
+
+const BaseText: React.VFC<Props> = (props): JSX.Element => {
+  const Tag = props.tagName
+    ? props.tagName
+    : ('span' as keyof JSX.IntrinsicElements)
+
+  const face = props.face ? props.face : 'normal'
+  const weight = props.weight ? props.weight : 'r'
+
+  return (
+    <Tag
+      className={[
+        styles[`face--${face}`],
+        styles[`weight--${weight}`],
+        styles[`sp_size--${props.sizeSp}`],
+        styles[`pc_size--${props.sizePc}`],
+        props.className,
+      ].join(' ')}
+    >
+      {props.children}
+    </Tag>
+  )
+}
+
+export default BaseText

--- a/components/BaseTitle.tsx
+++ b/components/BaseTitle.tsx
@@ -1,0 +1,25 @@
+import BaseText from '@/components/BaseText'
+
+type Props = {
+  face?: 'normal' | 'ja' | 'en'
+  weight?: 'r' | 'm' | 'b'
+  className?: string
+  level: '1' | '2' | '3' | '4' | '5' | '6'
+  sizeSp: number
+  sizePc: number
+  children: React.ReactNode
+}
+
+const BaseTitle: React.VFC<Props> = ({
+  level,
+  children,
+  ...props
+}): JSX.Element => {
+  return (
+    <BaseText tagName={`h${level}`} {...props}>
+      {children}
+    </BaseText>
+  )
+}
+
+export default BaseTitle

--- a/styles/BaseText.module.sass
+++ b/styles/BaseText.module.sass
@@ -1,0 +1,65 @@
+.face
+  &--normal
+    font-family: 'Fira Code', 'Noto Sans JP', sans-serif
+  &--ja
+    font-family: 'Noto Sans JP', sans-serif
+  &--en
+    font-family: 'Fira Code', monospace
+
+.weight
+  &--r
+    font-weight: 400
+  &--m
+    font-weight: 500
+  &--b
+    font-weight: 700
+
+@include sp
+  .sp_size
+    &--16
+      font-size: vw(16)
+    &--18
+      font-size: vw(18)
+    &--20
+      font-size: vw(20)
+    &--22
+      font-size: vw(22)
+    &--24
+      font-size: vw(24)
+    &--26
+      font-size: vw(26)
+    &--28
+      font-size: vw(28)
+    &--30
+      font-size: vw(30)
+    &--36
+      font-size: vw(36)
+    &--45
+      font-size: vw(45)
+    &--56
+      font-size: vw(56)
+
+@include pc
+  .pc_size
+    &--10
+      font-size: 10px
+    &--12
+      font-size: 12px
+    &--14
+      font-size: 14px
+    &--16
+      font-size: 18px
+    &--18
+      font-size: 18px
+    &--20
+      font-size: 20px
+    &--22
+      font-size: 22px
+    &--24
+      font-size: 24px
+    &--30
+      font-size: 30px
+    &--36
+      font-size: 36px
+    &--56
+      font-size: 56px


### PR DESCRIPTION
## Important
Merge #4 before this pull request.

## Overview
Added base text component.
It has `tagName`,  `children(react node)`, `className`, `font-family`, `font-size` and `font-weight` properties.

## Example
```
<BaseText
  tagName="p"
  className={styles.test}
  face="en"
  weight="m"
  sizeSp={20}
  sizePc={18}
>
  text...
</BaseText>
```

## Props
| # | Name | Type | Require | Default |
| - | ------ | ----- | -------- | :------: |
| 1 | tagName | JSX.IntrinsicElements | false | 'span' |
| 2 | face | 'normal' \| 'ja' \| 'en' | false | 'normal' |
| 3 | weight | 'r' \| 'm' \| 'b' | false | 'r' |
| 4 | className | string | false | - |
| 5 | sizeSp | number | true | - |
| 6 | sizePc | number | true | - |
| 7 | children | React.ReactNode | true | - |n