### PR TITLE
Add base title component

### DIFF
--- a/components/BaseTitle.tsx
+++ b/components/BaseTitle.tsx
@@ -1,0 +1,25 @@
+import BaseText from '@/components/BaseText'
+
+type Props = {
+  face?: 'normal' | 'ja' | 'en'
+  weight?: 'r' | 'm' | 'b'
+  className?: string
+  level: '1' | '2' | '3' | '4' | '5' | '6'
+  sizeSp: number
+  sizePc: number
+  children: React.ReactNode
+}
+
+const BaseTitle: React.VFC<Props> = ({
+  level,
+  children,
+  ...props
+}): JSX.Element => {
+  return (
+    <BaseText tagName={`h${level}`} {...props}>
+      {children}
+    </BaseText>
+  )
+}
+
+export default BaseTitle


### PR DESCRIPTION
## Important
Merge #3 after this pull request.

## Overview
Added base title component.
It has `level`,  `children(react node)`, `className`, `font-family`, `font-size` and `font-weight` properties.

## Example
```
<BaseTitle
  level="1"
  className={styles.test}
  sizeSp={56}
  sizePc={56}
>
  title
</BaseTitle>
```

## Props
| # | Name | Type | Require | Default |
| - | ------ | ----- | -------- | :------: |
| 1 | face | 'normal' \| 'ja' \| 'en' | false | depend #3 face  |
| 2 | weight | 'r' \| 'm' \| 'b' | false | depend #3 weight |
| 3 | className | string | false | - |
| 4 | level | '1' \| '2' \| '3' \| '4' \| '5' \| '6' | true | - |
| 5 | sizeSp | number | true | - |
| 6 | sizePc | number | true | - |
| 7 | children | React.ReactNode | true | - |n
