### PR TITLE
Add global css and styling entire pages background color and font color

### DIFF
--- a/styles/config.sass
+++ b/styles/config.sass
@@ -35,6 +35,7 @@ $pc-min-width: 1000
   @media screen and (min-width: #{$pc-size}px)
     @content
 
+<<<<<<< HEAD
 // Utils
 @mixin hoverOpacity
   &:active
@@ -43,3 +44,9 @@ $pc-min-width: 1000
   &:hover
     @include pc
       opacity: .8
+=======
+// Non-Retina
+@mixin nonRetina
+  @media screen and (-webkit-max-device-pixel-ratio: 1)
+    @content
+>>>>>>> eef3fd7 (Add: global css and styling entire pages background color)

--- a/styles/config.sass
+++ b/styles/config.sass
@@ -35,7 +35,11 @@ $pc-min-width: 1000
   @media screen and (min-width: #{$pc-size}px)
     @content
 
-<<<<<<< HEAD
+// Non-Retina
+@mixin nonRetina
+  @media screen and (-webkit-max-device-pixel-ratio: 1)
+    @content
+
 // Utils
 @mixin hoverOpacity
   &:active
@@ -44,9 +48,3 @@ $pc-min-width: 1000
   &:hover
     @include pc
       opacity: .8
-=======
-// Non-Retina
-@mixin nonRetina
-  @media screen and (-webkit-max-device-pixel-ratio: 1)
-    @content
->>>>>>> eef3fd7 (Add: global css and styling entire pages background color)

--- a/styles/globals.sass
+++ b/styles/globals.sass
@@ -90,6 +90,7 @@ svg
 
 body
   background: $c-light-blue
+  color: $c-black
   @include nonRetina
     background: $c-dark-blue
 

--- a/styles/globals.sass
+++ b/styles/globals.sass
@@ -87,3 +87,20 @@ select
 
 svg
   width: 100%
+
+body
+  background: $c-light-blue
+  @include nonRetina
+    background: $c-dark-blue
+
+.pc
+  @include sp
+    display: none !important
+  @include pc
+    display: block
+
+.sp
+  @include sp
+    display: block
+  @include pc
+    display: none !important


### PR DESCRIPTION
## Overview
Add global css and styling entire pages background color.

## Detail
- Added styles `.pc` and `.sp` to use when I want to switch display of a element dependent on device width.
- Styled entire pages background color.  

## About the nonRetina method of sass
I considered both of the `retina` and the `nonRetina` methods as I use media query to switch background color.
I decided to use the `nonRetina` because I thought difficult to judgement using the `retina` that is used many devices and I want to prioritize `retina` (background-color: #e6f2ff;).

### Retina Example1
```
@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
only screen and (-o-min-device-pixel-ratio: 3/2),
only screen and (min--moz-device-pixel-ratio: 1.5),
only screen and (min-device-pixel-ratio: 1.5) {
  something you want...
}
```
https://coliss.com/articles/build-websites/operation/css/media-query-cheat-sheet.html

### Retina Example2
```
@media 
(-webkit-min-device-pixel-ratio: 2), 
(min-resolution: 192dpi) { 
   something you want...
}
```
https://css-tricks.com/snippets/css/retina-display-media-query/

But patterns of `nonRetina` is easy to read and judgement.
### Non-Retina Example1
```
@media screen and (-webkit-max-device-pixel-ratio: 1) {
  something you want...
}
```
https://coliss.com/articles/build-websites/operation/css/media-query-cheat-sheet.html
